### PR TITLE
Client will raise an exception if API indicates invalid subscription

### DIFF
--- a/lib/prospector/client.rb
+++ b/lib/prospector/client.rb
@@ -9,6 +9,7 @@ module Prospector
 
       case response.code
       when "401" then raise AuthenticationError
+      when "402" then raise AccountSubscriptionStatusError, json[:error]
       when "200" then return true
       else
         raise UnknownError
@@ -27,6 +28,10 @@ module Prospector
 
     def endpoint
       @endpoint ||= URI('http://api.gemprospector.com/v1/specifications.json')
+    end
+
+    def json
+      @json ||= JSON.parse(response.body)
     end
 
     def build_request

--- a/lib/prospector/error.rb
+++ b/lib/prospector/error.rb
@@ -2,5 +2,6 @@ module Prospector
   class Error < StandardError; end
   class AuthenticationError < Error; end
   class InvalidCredentialsError < Error; end
+  class AccountSubscriptionStatusError < Error; end
   class UnknownError < Error; end
 end

--- a/spec/fixtures/vcr_cassettes/cancelled_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/cancelled_subscription.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.gemprospector.com/v1/specifications.json
+    body:
+      encoding: UTF-8
+      string: '{"specifications":[]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.gemprospector.com
+      X-Auth-Token:
+      - username
+      X-Auth-Secret:
+      - password
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 402
+      message: 'Payment Required '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 76c4e65a-54ae-4dfb-a5ff-aac6c7141a71
+      X-Runtime:
+      - '0.015806'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
+      Date:
+      - Mon, 20 Jul 2015 18:44:27 GMT
+      Content-Length:
+      - '85'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"error":"This account has been cancelled and all access was blocked starting on 2015-08-18."}'
+    http_version:
+  recorded_at: Mon, 20 Jul 2015 18:44:27 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/expired_trial.yml
+++ b/spec/fixtures/vcr_cassettes/expired_trial.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.gemprospector.com/v1/specifications.json
+    body:
+      encoding: UTF-8
+      string: '{"specifications":[]}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.gemprospector.com
+      X-Auth-Token:
+      - username
+      X-Auth-Secret:
+      - password
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 402
+      message: 'Payment Required '
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 76c4e65a-54ae-4dfb-a5ff-aac6c7141a71
+      X-Runtime:
+      - '0.015806'
+      Server:
+      - WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
+      Date:
+      - Mon, 20 Jul 2015 18:44:27 GMT
+      Content-Length:
+      - '85'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"error":"This account is expired and requires payment information
+        to continue use."}'
+    http_version:
+  recorded_at: Mon, 20 Jul 2015 18:44:27 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
If the trial has expired, or the account itself has been cancelled, the
client will now raise an error.
