### PR TITLE
Fixes autoloading of background jobs

### DIFF
--- a/lib/prospector.rb
+++ b/lib/prospector.rb
@@ -11,6 +11,7 @@ require "prospector/railtie" if defined?(Rails)
 
 begin
   require "pry"
+  require "sidekiq"
 rescue LoadError
 end
 

--- a/lib/prospector/background.rb
+++ b/lib/prospector/background.rb
@@ -1,9 +1,9 @@
-require "prospector/background/coordinator"
-require "prospector/background/notify_job" if defined?(ActiveJob::Base)
-require "prospector/background/notify_worker" if defined?(Sidekiq::Worker)
-
 module Prospector
   module Background
+    autoload :Coordinator,  'prospector/background/coordinator'
+    autoload :NotifyJob,    'prospector/background/notify_job'
+    autoload :NotifyWorker, 'prospector/background/notify_worker'
+
     def enqueue
       Coordinator.new.enqueue
     end

--- a/lib/prospector/background/coordinator.rb
+++ b/lib/prospector/background/coordinator.rb
@@ -19,13 +19,13 @@ module Prospector; module Background
     end
 
     def enqueue_via_active_job
-      raise UnsupportedAdapterError unless defined?(NotifyJob)
+      raise UnsupportedAdapterError unless Object.const_defined?('ActiveJob::Base')
 
       NotifyJob.perform_later
     end
 
     def enqueue_via_sidekiq
-      raise UnsupportedAdapterError unless defined?(NotifyWorker)
+      raise UnsupportedAdapterError unless Object.const_defined?('Sidekiq::Worker')
 
       NotifyWorker.perform_async
     end

--- a/lib/prospector/railtie.rb
+++ b/lib/prospector/railtie.rb
@@ -1,9 +1,7 @@
 module Prospector
   class Railtie < Rails::Railtie
-    initializer 'prospector.railtie' do |app|
-      ActiveSupport.on_load :action_controller do |app|
-        Background.enqueue
-      end
+    config.after_initialize do
+      Background.enqueue
     end
   end
 end


### PR DESCRIPTION
Ran into issues with Sidekiq not being loaded early enough in the boot
process to see that it was available and autoloading helps resolve that.

Additionally this was ran too early in the application lifecycle.
