### PR TITLE
Adds "none" option for background adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,21 @@ end
 
 Rails integration includes automatic detection and support for ActiveJob as well as Sidekiq, to deliver usage details to the Prospector API in the background on app boot.  Additionally, the rake task mentioned below is available to use at any time you see fit, for example as part of your deployment process.
 
-Valid background adapter options are `active_job`, `sidekiq`, and `none`.  ActiveJob is preferred and chosen in Rais 4.2 and above with built-in ActiveJob support.
+Valid background adapter options are `active_job`, `sidekiq`, `inline`, and `none`.  ActiveJob is preferred and chosen in Rais 4.2 and above with built-in ActiveJob support.
+
+```ruby
+# config/initializers/prospector.rb
+
+Prospector.configure do |config|
+  # Will default to using ActiveJob
+  # config.background_adapter = :active_job
+  # config.background_adapter = :sidekiq
+  # config.background_adapter = :inline
+  # config.background_adapter = :none
+end
+```
+
+You can use the `none` background adapter to skip sending information to the API automatically, and instead call at any point in time you see fit, whether via the rake task or manually.
 
 ### RubyMotion
 
@@ -87,7 +101,7 @@ rake prospector:deliver
 If you prefer to notify the Prospector API without using the included Rails or RubyMotion support, you can always call directly.
 
 ```ruby
-Prospector.notify!
+Prospector.notify! if Prospector.enabled?
 ```
 
 ## Development

--- a/lib/prospector/background/coordinator.rb
+++ b/lib/prospector/background/coordinator.rb
@@ -6,7 +6,8 @@ module Prospector; module Background
       case adapter_name
       when :active_job then enqueue_via_active_job
       when :sidekiq then enqueue_via_sidekiq
-      when :none then perform_immediately
+      when :inline then perform_immediately
+      when :none then return
       else
         raise UnsupportedAdapterError.new(adapter_name)
       end

--- a/spec/prospector/background/coordinator_spec.rb
+++ b/spec/prospector/background/coordinator_spec.rb
@@ -8,6 +8,20 @@ module Prospector
       end
     end
 
+    context 'when inline' do
+      before do
+        Prospector.configure do |config|
+          config.background_adapter = :inline
+        end
+      end
+
+      it 'performs immediately' do
+        expect(Prospector).to receive(:notify!)
+
+        subject.enqueue
+      end
+    end
+
     context 'when none' do
       before do
         Prospector.configure do |config|
@@ -15,9 +29,8 @@ module Prospector
         end
       end
 
-
-      it 'performs immediately' do
-        expect(Prospector).to receive(:notify!)
+      it 'skips calling our API' do
+        expect(Prospector).not_to receive(:notify!)
 
         subject.enqueue
       end


### PR DESCRIPTION
Allow users to specify that even though Prospector is enabled in their
app, they do not want to enqueue a background job.

Allows users to queue a job manually, hook into their deploy process,
and more.
