### PR TITLE
Allow easier customization of endpoint and credentials

### DIFF
--- a/lib/prospector/client.rb
+++ b/lib/prospector/client.rb
@@ -1,7 +1,17 @@
 module Prospector
   class Client
+    DEFAULT_ENDPOINT = 'http://api.gemprospector.com/v1/specifications.json'
+
+    attr_reader :endpoint
+
     def self.deliver(*args)
       new.deliver(*args)
+    end
+
+    def initialize(endpoint = DEFAULT_ENDPOINT, secret_token = nil, client_secret = nil)
+      @endpoint       = URI(endpoint)
+      @secret_token   = secret_token
+      @client_secret  = client_secret
     end
 
     def deliver(specifications)
@@ -16,6 +26,14 @@ module Prospector
       end
     end
 
+    def client_secret
+      @client_secret ||= Prospector.configuration.client_secret
+    end
+
+    def secret_token
+      @secret_token ||= Prospector.configuration.secret_token
+    end
+
     private
 
     def request
@@ -26,18 +44,14 @@ module Prospector
       @response ||= make_request
     end
 
-    def endpoint
-      @endpoint ||= URI('http://api.gemprospector.com/v1/specifications.json')
-    end
-
     def json
       @json ||= JSON.parse(response.body)
     end
 
     def build_request
       request = Net::HTTP::Post.new(endpoint)
-      request['X-Auth-Token']   = Prospector.configuration.secret_token
-      request['X-Auth-Secret']  = Prospector.configuration.client_secret
+      request['X-Auth-Token']   = secret_token
+      request['X-Auth-Secret']  = client_secret
       request['Content-Type']   = 'application/json'
       request
     end

--- a/spec/prospector/client_spec.rb
+++ b/spec/prospector/client_spec.rb
@@ -9,6 +9,10 @@ module Prospector
       end
     end
 
+    it 'returns the default endpoint' do
+      expect(subject.endpoint).to eq(URI(Prospector::Client::DEFAULT_ENDPOINT))
+    end
+
     context 'with invalid credentials' do
       let(:specifications) { [] }
 
@@ -49,6 +53,30 @@ module Prospector
         VCR.use_cassette 'cancelled_subscription' do
           expect { subject.deliver(specifications) }.to raise_error(AccountSubscriptionStatusError)
         end
+      end
+    end
+
+    describe 'when provided custom endpoint and credentials' do
+      let(:specifications) { [] }
+
+      subject do
+        described_class.new('http://api.lvh.me:3000', 'custom_token', 'custom_secret')
+      end
+
+      it 'returns the endpoint as a URI' do
+        expect(subject.endpoint).to be_a(URI)
+      end
+
+      it 'returns the correct endpoint we passed in' do
+        expect(subject.endpoint).to eq(URI('http://api.lvh.me:3000'))
+      end
+
+      it 'returns our custom token' do
+        expect(subject.secret_token).to eq('custom_token')
+      end
+
+      it 'returns our custom secret' do
+        expect(subject.client_secret).to eq('custom_secret')
       end
     end
   end


### PR DESCRIPTION
Add ability to provide custom endpoint and credentials if you’re
manually creating an instance of the client.

Should make things easier when doing development on the gem locally.
