### PR TITLE
Report ruby version info to API

### DIFF
--- a/lib/prospector.rb
+++ b/lib/prospector.rb
@@ -4,6 +4,7 @@ require "net/http"
 
 require "prospector/version"
 
+require "prospector/ruby_version"
 require "prospector/client"
 require "prospector/configuration"
 require "prospector/error"
@@ -35,6 +36,10 @@ module Prospector
 
     def enabled?
       configuration.enabled?
+    end
+
+    def ruby_version
+      @ruby_version ||= RubyVersion.new
     end
 
     def notify!

--- a/lib/prospector.rb
+++ b/lib/prospector.rb
@@ -49,7 +49,7 @@ module Prospector
 
       specifications = Bundler.environment.specs
 
-      Client.deliver(specifications)
+      Client.deliver(specifications, ruby_version)
     end
   end
 

--- a/lib/prospector/client.rb
+++ b/lib/prospector/client.rb
@@ -14,8 +14,8 @@ module Prospector
       @client_secret  = client_secret
     end
 
-    def deliver(specifications)
-      set_request_body(specifications)
+    def deliver(specifications, ruby_version)
+      set_request_body(specifications, ruby_version)
 
       case response.code
       when "401" then raise AuthenticationError
@@ -56,8 +56,9 @@ module Prospector
       request
     end
 
-    def set_request_body(specifications)
+    def set_request_body(specifications, ruby_version)
       request.body = {
+        ruby_version: ruby_version.to_json,
         specifications: hash_from_specifications(specifications)
       }.to_json
     end

--- a/lib/prospector/ruby_version.rb
+++ b/lib/prospector/ruby_version.rb
@@ -1,0 +1,21 @@
+module Prospector
+  class RubyVersion
+    extend Forwardable
+
+    def_delegators :@ruby_version, :version, :patchlevel, :engine, :engine_version, :to_s
+    alias_method :patch_level, :patchlevel
+
+    def initialize
+      @ruby_version = Bundler.ruby_version
+    end
+
+    def to_json
+      {
+        engine: engine,
+        engine_version: engine_version,
+        version: version,
+        patch_level: patch_level
+      }
+    end
+  end
+end

--- a/spec/propsector_spec.rb
+++ b/spec/propsector_spec.rb
@@ -56,7 +56,7 @@ describe Prospector do
 
       it 'delivers the specifications' do
         allow(Bundler).to receive(:environment).and_return(double(specs: []))
-        expect(Prospector::Client).to receive(:deliver).with([])
+        expect(Prospector::Client).to receive(:deliver).with([], Prospector.ruby_version)
 
         subject.notify!
       end

--- a/spec/prospector/client_spec.rb
+++ b/spec/prospector/client_spec.rb
@@ -18,7 +18,7 @@ module Prospector
 
       it 'raises error' do
         VCR.use_cassette 'invalid credentials' do
-          expect { subject.deliver(specifications) }.to raise_error(AuthenticationError)
+          expect { subject.deliver(specifications, Prospector.ruby_version) }.to raise_error(AuthenticationError)
         end
       end
     end
@@ -29,7 +29,7 @@ module Prospector
 
       it 'returns true' do
         VCR.use_cassette 'valid credentials' do
-          expect(subject.deliver(specifications)).to be_truthy
+          expect(subject.deliver(specifications, Prospector.ruby_version)).to be_truthy
         end
       end
     end
@@ -39,19 +39,19 @@ module Prospector
 
       it 'raises an exception for a 500 error' do
         VCR.use_cassette 'server 500 error' do
-          expect { subject.deliver(specifications) }.to raise_error(UnknownError)
+          expect { subject.deliver(specifications, Prospector.ruby_version) }.to raise_error(UnknownError)
         end
       end
 
       it 'warns for expired accounts' do
         VCR.use_cassette 'expired_trial' do
-          expect { subject.deliver(specifications) }.to raise_error(AccountSubscriptionStatusError)
+          expect { subject.deliver(specifications, Prospector.ruby_version) }.to raise_error(AccountSubscriptionStatusError)
         end
       end
 
       it 'warns for cancelled accounts' do
         VCR.use_cassette 'cancelled_subscription' do
-          expect { subject.deliver(specifications) }.to raise_error(AccountSubscriptionStatusError)
+          expect { subject.deliver(specifications, Prospector.ruby_version) }.to raise_error(AccountSubscriptionStatusError)
         end
       end
     end

--- a/spec/prospector/ruby_version_spec.rb
+++ b/spec/prospector/ruby_version_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Prospector::RubyVersion do
+  let(:bundler_ruby_version) { Bundler.ruby_version }
+
+  subject { described_class.new }
+
+  describe '#to_json' do
+    it 'returns a Hash' do
+      expect(subject.to_json).to be_a(Hash)
+    end
+
+    it 'returns the information to build a new Bundler::RubyVersion later' do
+      json = subject.to_json
+
+      expect(json).to include(engine: bundler_ruby_version.engine)
+      expect(json).to include(engine_version: bundler_ruby_version.engine_version)
+      expect(json).to include(version: bundler_ruby_version.version)
+      expect(json).to include(patch_level: bundler_ruby_version.patchlevel)
+    end
+  end
+
+  describe 'attributes' do
+    it 'delegates #version' do
+      expect(subject.version).to eq(bundler_ruby_version.version)
+    end
+
+    it 'delegates #patch_level' do
+      expect(subject.patch_level).to eq(bundler_ruby_version.patchlevel)
+    end
+
+    it 'delegates #engine' do
+      expect(subject.engine).to eq(bundler_ruby_version.engine)
+    end
+
+    it 'delegates #engine_version' do
+      expect(subject.engine_version).to eq(bundler_ruby_version.engine_version)
+    end
+  end
+end


### PR DESCRIPTION
Capture the ruby version and platform information to send along to the API for storage.
