### PR TITLE
Support Bundler 1.12+

### DIFF
--- a/lib/prospector/ruby_version.rb
+++ b/lib/prospector/ruby_version.rb
@@ -2,11 +2,11 @@ module Prospector
   class RubyVersion
     extend Forwardable
 
-    def_delegators :@ruby_version, :version, :patchlevel, :engine, :engine_version, :to_s
+    def_delegators :@ruby_version, :patchlevel, :engine
     alias_method :patch_level, :patchlevel
 
     def initialize
-      @ruby_version = Bundler.ruby_version
+      @ruby_version = Bundler::RubyVersion.system
     end
 
     def to_json
@@ -16,6 +16,18 @@ module Prospector
         version: version,
         patch_level: patch_level
       }
+    end
+
+    def engine_version
+      @ruby_version.engine_gem_version.version
+    end
+
+    def version
+      @ruby_version.gem_version.version
+    end
+
+    def to_s
+      @ruby_version.single_version_string
     end
   end
 end

--- a/prospector.gemspec
+++ b/prospector.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "json", "~> 1.8"
-  spec.add_dependency "bundler", "~> 1.10"
+  spec.add_dependency "bundler", "~> 1.12"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "webmock", "~> 1.21"

--- a/spec/prospector/ruby_version_spec.rb
+++ b/spec/prospector/ruby_version_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Prospector::RubyVersion do
-  let(:bundler_ruby_version) { Bundler.ruby_version }
+  let(:bundler_ruby_version) { Bundler::RubyVersion.system }
 
   subject { described_class.new }
 
@@ -14,15 +14,15 @@ describe Prospector::RubyVersion do
       json = subject.to_json
 
       expect(json).to include(engine: bundler_ruby_version.engine)
-      expect(json).to include(engine_version: bundler_ruby_version.engine_version)
-      expect(json).to include(version: bundler_ruby_version.version)
+      expect(json).to include(engine_version: bundler_ruby_version.engine_gem_version.version)
+      expect(json).to include(version: bundler_ruby_version.gem_version.version)
       expect(json).to include(patch_level: bundler_ruby_version.patchlevel)
     end
   end
 
   describe 'attributes' do
     it 'delegates #version' do
-      expect(subject.version).to eq(bundler_ruby_version.version)
+      expect(subject.version).to eq(bundler_ruby_version.gem_version.version)
     end
 
     it 'delegates #patch_level' do
@@ -34,7 +34,7 @@ describe Prospector::RubyVersion do
     end
 
     it 'delegates #engine_version' do
-      expect(subject.engine_version).to eq(bundler_ruby_version.engine_version)
+      expect(subject.engine_version).to eq(bundler_ruby_version.engine_gem_version.version)
     end
   end
 end


### PR DESCRIPTION
Bundler refactored some internal methods that we rely upon, and caused
error with Prospector.

Bundler 1.12 has been available for close a year, so setting that as
our lowest supported version doesn’t bother me.

https://github.com/bundler/bundler/commit/aa0dd2d4dbdb1d929ce19f15f2670e
4fca9fe469